### PR TITLE
fix: crc32 hardware accelerated hashing on silicon Macs

### DIFF
--- a/tools/extract_keywords.cpp
+++ b/tools/extract_keywords.cpp
@@ -54,17 +54,18 @@ private:
             const char* data = str.c_str();
             size_t len = str.length();
             
-            // Process 4 bytes at a time (safer than 8)
-            while (len >= 4) {
+            // Process 8 bytes at a time
+            while (len >= 8) {
                 uint32_t chunk;
                 memcpy(&chunk, data, 4);
                 hash = __crc32w(hash, chunk);
-                data += 4;
-                len -= 4;
+                data += 8;
+                len -= 8;
             }
             
             // Handle remaining bytes
             while (len > 0) {
+                // TEST and test should be the same
                 hash = __crc32b(hash, std::toupper(*data++));
                 len--;
             }


### PR DESCRIPTION
 - Closes #1 

Added the function provided in the original issue as it is within the class as a starting point. Compiles hash_keyword with crc32 acceleration if running on a mac otherwise falls back to fnv1a implementation.

In Draft Phase right now - Partial implementation only.