### PR TITLE
tokenizer: consume an unterminated block comment to end of input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,16 @@ if(BUILD_TESTS)
             DB25::Tokenizer
     )
 
+    # Block comment test executable - regression test for unterminated block comments
+    add_executable(test_block_comment
+        test/test_block_comment.cpp
+    )
+
+    target_link_libraries(test_block_comment
+        PRIVATE
+            DB25::Tokenizer
+    )
+
     # Copy test data to build directory
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/test/sql_test.sqls
@@ -274,6 +284,16 @@ if(BUILD_TESTS)
         FAIL_REGULAR_EXPRESSION "FAIL;should be rejected"
     )
 
+    add_test(
+        NAME BlockCommentTest
+        COMMAND test_block_comment
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(BlockCommentTest PROPERTIES
+        PASS_REGULAR_EXPRESSION "All tests passed. No regressions detected"
+        FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
+    )
+
     # Performance regression test - ensure tokenizer is fast enough
     add_test(
         NAME PerformanceTest
@@ -286,7 +306,7 @@ if(BUILD_TESTS)
 
     # Set test properties for all tests
     set_tests_properties(TokenizerBasicTest TokenizerVerboseTest TokenizerOutputTest
-                        OperatorTest InvalidOperatorTest PerformanceTest
+                        OperatorTest InvalidOperatorTest BlockCommentTest PerformanceTest
         PROPERTIES
             TIMEOUT 10
             LABELS "tokenizer"
@@ -295,7 +315,7 @@ if(BUILD_TESTS)
     # Add custom target for running tests
     add_custom_target(check
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
-        DEPENDS test_sql_file test_operators test_invalid_operators
+        DEPENDS test_sql_file test_operators test_invalid_operators test_block_comment
         COMMENT "Running all tokenizer tests with strict validation"
     )
 endif()

--- a/src/simd_tokenizer.cpp
+++ b/src/simd_tokenizer.cpp
@@ -230,12 +230,14 @@ Token SimdTokenizer::scan_comment(size_t start, size_t start_line, size_t start_
 Token SimdTokenizer::scan_block_comment(size_t start, size_t start_line, size_t start_column) {
         position_ += 2;
         column_ += 2;
-        
+
+        bool terminated = false;
         while (position_ + 1 < input_size_) {
             if (static_cast<uint8_t>(input_[position_]) == '*' &&
                 static_cast<uint8_t>(input_[position_ + 1]) == '/') {
                 position_ += 2;
                 column_ += 2;
+                terminated = true;
                 break;
             } else if (static_cast<uint8_t>(input_[position_]) == '\n') {
                 ++position_;
@@ -246,12 +248,21 @@ Token SimdTokenizer::scan_block_comment(size_t start, size_t start_line, size_t 
                 ++column_;
             }
         }
-        
+
+        // Unterminated block comment: the loop above stops one byte early
+        // (position_ + 1 < input_size_), which would leave a trailing byte to be
+        // re-tokenized as a spurious token. Consume the remainder so the whole
+        // input becomes a single Comment token, mirroring scan_comment's EOF
+        // handling.
+        if (!terminated) {
+            position_ = input_size_;
+        }
+
         std::string_view value(
             reinterpret_cast<const char*>(input_ + start),
             position_ - start
         );
-        
+
         return {TokenType::Comment, value, Keyword::UNKNOWN, start_line, start_column};
     }
 

--- a/test/test_block_comment.cpp
+++ b/test/test_block_comment.cpp
@@ -1,0 +1,162 @@
+/*
+ * Block comment test for DB25 SQL Tokenizer
+ * Regression test for unterminated block comment handling.
+ *
+ * Bug: scan_block_comment looped `while (position_ + 1 < input_size_)`, so for
+ * an unterminated block comment (a slash-star with no closing star-slash) the
+ * loop exited one byte early. The final byte was dropped from the Comment token
+ * and re-tokenized as a spurious trailing token (Comment losing its last byte,
+ * plus a stray Identifier). The fix consumes to end of input when no closing
+ * star-slash is found, mirroring scan_comment's EOF handling.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cassert>
+#include "simd_tokenizer.hpp"
+
+using namespace db25;
+
+struct ExpectedToken {
+    TokenType type;
+    std::string value;
+};
+
+struct BlockCommentTest {
+    std::string sql;
+    std::vector<ExpectedToken> expected_tokens;
+    std::string description;
+};
+
+const char* token_type_to_string(TokenType type) {
+    switch (type) {
+        case TokenType::Unknown: return "Unknown";
+        case TokenType::Keyword: return "Keyword";
+        case TokenType::Identifier: return "Identifier";
+        case TokenType::Number: return "Number";
+        case TokenType::String: return "String";
+        case TokenType::Operator: return "Operator";
+        case TokenType::Delimiter: return "Delimiter";
+        case TokenType::Comment: return "Comment";
+        case TokenType::Whitespace: return "Whitespace";
+        case TokenType::EndOfFile: return "EOF";
+        default: return "?";
+    }
+}
+
+bool test_block_comment(const BlockCommentTest& test) {
+    SimdTokenizer tokenizer(
+        reinterpret_cast<const std::byte*>(test.sql.data()),
+        test.sql.size()
+    );
+
+    auto tokens = tokenizer.tokenize();
+
+    // Extract non-whitespace, non-EOF tokens
+    std::vector<Token> actual_tokens;
+    for (const auto& token : tokens) {
+        if (token.type != TokenType::Whitespace &&
+            token.type != TokenType::EndOfFile) {
+            actual_tokens.push_back(token);
+        }
+    }
+
+    // Strict comparison of both count and (type, value) of every token
+    if (actual_tokens.size() != test.expected_tokens.size()) {
+        std::cerr << "✗ FAIL: " << test.description << "\n";
+        std::cerr << "  SQL: \"" << test.sql << "\"\n";
+        std::cerr << "  Expected " << test.expected_tokens.size()
+                  << " tokens, got " << actual_tokens.size() << "\n";
+        std::cerr << "  Expected: ";
+        for (const auto& t : test.expected_tokens)
+            std::cerr << "[" << token_type_to_string(t.type) << ":" << t.value << "] ";
+        std::cerr << "\n  Got:      ";
+        for (const auto& t : actual_tokens)
+            std::cerr << "[" << token_type_to_string(t.type) << ":" << std::string(t.value) << "] ";
+        std::cerr << "\n";
+        return false;
+    }
+
+    for (size_t i = 0; i < actual_tokens.size(); ++i) {
+        if (actual_tokens[i].type != test.expected_tokens[i].type ||
+            std::string(actual_tokens[i].value) != test.expected_tokens[i].value) {
+            std::cerr << "✗ FAIL: " << test.description << "\n";
+            std::cerr << "  SQL: \"" << test.sql << "\"\n";
+            std::cerr << "  Token " << i << " mismatch: expected ["
+                      << token_type_to_string(test.expected_tokens[i].type) << ":"
+                      << test.expected_tokens[i].value << "], got ["
+                      << token_type_to_string(actual_tokens[i].type) << ":"
+                      << std::string(actual_tokens[i].value) << "]\n";
+            return false;
+        }
+    }
+
+    std::cout << "✓ PASS: " << test.description << "\n";
+    return true;
+}
+
+int main() {
+    std::cout << "DB25 Tokenizer - Block Comment Test\n";
+    std::cout << "===================================\n\n";
+
+    std::vector<BlockCommentTest> tests = {
+        // Regression: unterminated block comment must be ONE Comment token that
+        // spans to EOF, with no spurious trailing Identifier.
+        {"/* unterminated",
+         {{TokenType::Comment, "/* unterminated"}},
+         "Unterminated block comment is a single Comment to EOF"},
+
+        // Regression: the originally reported reproducer "/* bad".
+        {"/* bad",
+         {{TokenType::Comment, "/* bad"}},
+         "Unterminated '/* bad' keeps its final byte (no trailing Identifier)"},
+
+        // Control: terminated block comment followed by an identifier.
+        {"/* ok */x",
+         {{TokenType::Comment, "/* ok */"}, {TokenType::Identifier, "x"}},
+         "Terminated block comment then identifier"},
+
+        // Edge: bare "/*" at exact EOF is a single (empty-body) Comment token.
+        {"/*",
+         {{TokenType::Comment, "/*"}},
+         "Bare '/*' at EOF is a single Comment"},
+
+        // Edge: empty terminated comment.
+        {"/**/",
+         {{TokenType::Comment, "/**/"}},
+         "Empty terminated block comment '/**/'"},
+
+        // Edge: unterminated comment ending right after a newline.
+        {"/* multi\nline",
+         {{TokenType::Comment, "/* multi\nline"}},
+         "Unterminated multi-line block comment spans to EOF"},
+    };
+
+    int passed = 0;
+    int failed = 0;
+
+    for (const auto& test : tests) {
+        if (test_block_comment(test)) {
+            passed++;
+        } else {
+            failed++;
+            assert(false && "Block comment test failed - tokenizer not handling block comments correctly!");
+        }
+    }
+
+    std::cout << "\n" << std::string(50, '=') << "\n";
+    std::cout << "Test Summary\n";
+    std::cout << std::string(50, '=') << "\n";
+    std::cout << "Total Tests: " << tests.size() << "\n";
+    std::cout << "Passed:      " << passed << "\n";
+    std::cout << "Failed:      " << failed << "\n";
+
+    if (failed > 0) {
+        std::cerr << "\n⚠️  Some block comment tests failed! Please review the failures above.\n";
+        return 1;
+    } else {
+        std::cout << "\n✅ All tests passed. No regressions detected.\n";
+        return 0;
+    }
+}


### PR DESCRIPTION
## Problem

`scan_block_comment`'s scan loop is `while (position_ + 1 < input_size_)` (needed for the two-byte `*/` lookahead). When a block comment is never closed, the loop stops one byte early — at `position_ == input_size_ - 1` — so the `Comment` token dropped its final byte, and that byte was re-tokenized as a spurious trailing token:

```
/* bad   →   Comment "/* ba"  +  Identifier "d"
```

The line-comment scanner (`scan_comment`) already handles EOF correctly (`while (position_ < input_size_)`); the block-comment scanner did not.

## Fix

Track whether the closing `*/` was seen. If the loop ends without it, advance `position_` to `input_size_` so the whole remainder becomes a single `Comment` token — mirroring `scan_comment`'s EOF handling. The terminated path (`*/` found) is byte-for-byte unchanged.

## Tests

New `test/test_block_comment.cpp` (checks token **type and value**): unterminated → a single `Comment` to EOF (no trailing `Identifier`); `/* bad` keeps its final byte; `/*` at exact EOF; `/**/`; unterminated multi-line spans to EOF; terminated control (`/* ok */x`). The suite **fails on the pre-fix tokenizer** and passes after. Full CTest suite green (7/7), no warnings under `-Wall -Wextra -Wpedantic`.

The SIMD paths are untouched — this is a scalar-scanner correctness fix.