### PR TITLE
tokenizer: lex hex/binary integer and leading-dot float literals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,16 @@ if(BUILD_TESTS)
             DB25::Tokenizer
     )
 
+    # Number-literal test executable - hex/binary/leading-dot literal boundaries
+    add_executable(test_number_literals
+        test/test_number_literals.cpp
+    )
+
+    target_link_libraries(test_number_literals
+        PRIVATE
+            DB25::Tokenizer
+    )
+
     # Copy test data to build directory
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/test/sql_test.sqls
@@ -294,6 +304,16 @@ if(BUILD_TESTS)
         FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
     )
 
+    add_test(
+        NAME NumberLiteralTest
+        COMMAND test_number_literals
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(NumberLiteralTest PROPERTIES
+        PASS_REGULAR_EXPRESSION "All tests passed. No regressions detected"
+        FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
+    )
+
     # Performance regression test - ensure tokenizer is fast enough
     add_test(
         NAME PerformanceTest
@@ -306,7 +326,8 @@ if(BUILD_TESTS)
 
     # Set test properties for all tests
     set_tests_properties(TokenizerBasicTest TokenizerVerboseTest TokenizerOutputTest
-                        OperatorTest InvalidOperatorTest BlockCommentTest PerformanceTest
+                        OperatorTest InvalidOperatorTest BlockCommentTest
+                        NumberLiteralTest PerformanceTest
         PROPERTIES
             TIMEOUT 10
             LABELS "tokenizer"
@@ -316,6 +337,7 @@ if(BUILD_TESTS)
     add_custom_target(check
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
         DEPENDS test_sql_file test_operators test_invalid_operators test_block_comment
+                test_number_literals
         COMMENT "Running all tokenizer tests with strict validation"
     )
 endif()

--- a/src/simd_tokenizer.cpp
+++ b/src/simd_tokenizer.cpp
@@ -77,6 +77,13 @@ Token SimdTokenizer::next_token() {
             return scan_number(start, start_line, start_column);
         }
 
+        // Leading-dot float: `.5` is a number, not the `.` delimiter. Only when a
+        // digit follows the dot (so member/qualifier `.` and `t.*` are untouched).
+        if (first_char == '.' && position_ + 1 < input_size_ &&
+            is_digit(static_cast<uint8_t>(input_[position_ + 1]))) {
+            return scan_number(start, start_line, start_column);
+        }
+
         if (is_quote(first_char)) {
             return scan_string(start, start_line, start_column, first_char);
         }
@@ -133,6 +140,47 @@ Token SimdTokenizer::scan_identifier_or_keyword(size_t start, size_t start_line,
 Token SimdTokenizer::scan_number(size_t start, size_t start_line, size_t start_column) {
         bool has_dot = false;
         bool has_exp = false;
+
+        // Hex (0x..) / binary (0b..) integer literals: a leading '0' followed by
+        // x/X (base 16) or b/B (base 2) scans the whole prefixed literal as a
+        // single Number token, instead of stopping at the letter and leaving the
+        // rest to be mis-read as an identifier (which turned `0xFF` into `0` + an
+        // alias `xFF`, i.e. a silent value of 0). The value is parsed downstream.
+        if (static_cast<uint8_t>(input_[position_]) == '0' &&
+            position_ + 1 < input_size_) {
+            const uint8_t radix = static_cast<uint8_t>(input_[position_ + 1]);
+            const auto is_hex = [](uint8_t c) {
+                return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+                       (c >= 'A' && c <= 'F');
+            };
+            if (radix == 'x' || radix == 'X') {
+                position_ += 2;
+                column_ += 2;
+                while (position_ < input_size_ &&
+                       is_hex(static_cast<uint8_t>(input_[position_]))) {
+                    ++position_;
+                    ++column_;
+                }
+                return {TokenType::Number,
+                        std::string_view(reinterpret_cast<const char*>(input_ + start),
+                                         position_ - start),
+                        Keyword::UNKNOWN, start_line, start_column};
+            }
+            if (radix == 'b' || radix == 'B') {
+                position_ += 2;
+                column_ += 2;
+                while (position_ < input_size_ &&
+                       (static_cast<uint8_t>(input_[position_]) == '0' ||
+                        static_cast<uint8_t>(input_[position_]) == '1')) {
+                    ++position_;
+                    ++column_;
+                }
+                return {TokenType::Number,
+                        std::string_view(reinterpret_cast<const char*>(input_ + start),
+                                         position_ - start),
+                        Keyword::UNKNOWN, start_line, start_column};
+            }
+        }
 
         while (position_ < input_size_) {
             uint8_t ch = static_cast<uint8_t>(input_[position_]);

--- a/test/test_number_literals.cpp
+++ b/test/test_number_literals.cpp
@@ -1,0 +1,145 @@
+/*
+ * Number-literal tokenization test for DB25 SQL Tokenizer
+ *
+ * Covers the lexeme boundaries of numeric literals, in particular:
+ *   - hex (0x..) and binary (0b..) integer literals, which must be a single
+ *     Number token rather than `0` + an identifier tail (the old behaviour
+ *     silently read `0xFF` as the number 0 followed by an alias `xFF`);
+ *   - leading-dot floats (`.5`), which must lex as a Number, not the `.`
+ *     delimiter followed by `5`;
+ *   - the existing decimal / exponent forms, as a regression guard;
+ *   - shapes that must NOT be swallowed by the new rules: a bare `0`, the `.`
+ *     member operator, and `t.*`.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include "simd_tokenizer.hpp"
+
+using namespace db25;
+
+struct TokExp {
+    TokenType type;
+    std::string value;
+};
+
+struct TestCase {
+    std::string sql;
+    std::vector<TokExp> expected;  // non-whitespace, non-EOF tokens
+    std::string description;
+};
+
+static const char* type_name(TokenType t) {
+    switch (t) {
+        case TokenType::Unknown: return "Unknown";
+        case TokenType::Keyword: return "Keyword";
+        case TokenType::Identifier: return "Identifier";
+        case TokenType::Number: return "Number";
+        case TokenType::String: return "String";
+        case TokenType::Operator: return "Operator";
+        case TokenType::Delimiter: return "Delimiter";
+        case TokenType::Comment: return "Comment";
+        case TokenType::Whitespace: return "Whitespace";
+        case TokenType::EndOfFile: return "EOF";
+        default: return "?";
+    }
+}
+
+static bool run(const TestCase& test) {
+    SimdTokenizer tokenizer(
+        reinterpret_cast<const std::byte*>(test.sql.data()),
+        test.sql.size());
+    auto tokens = tokenizer.tokenize();
+
+    std::vector<Token> actual;
+    for (const auto& tok : tokens) {
+        if (tok.type != TokenType::Whitespace && tok.type != TokenType::EndOfFile) {
+            actual.push_back(tok);
+        }
+    }
+
+    bool ok = actual.size() == test.expected.size();
+    for (size_t i = 0; ok && i < actual.size(); ++i) {
+        if (actual[i].type != test.expected[i].type ||
+            std::string(actual[i].value) != test.expected[i].value) {
+            ok = false;
+        }
+    }
+
+    if (!ok) {
+        std::cout << "✗ FAIL: " << test.description << "\n";
+        std::cout << "  SQL: \"" << test.sql << "\"\n";
+        std::cout << "  Expected: ";
+        for (const auto& e : test.expected)
+            std::cout << "[" << type_name(e.type) << ":" << e.value << "] ";
+        std::cout << "\n  Got:      ";
+        for (const auto& a : actual)
+            std::cout << "[" << type_name(a.type) << ":" << std::string(a.value) << "] ";
+        std::cout << "\n";
+        return false;
+    }
+
+    std::cout << "✓ PASS: " << test.description << "\n";
+    return true;
+}
+
+int main() {
+    std::cout << "DB25 Tokenizer - Number Literal Test\n";
+    std::cout << "====================================\n\n";
+
+    const auto N = TokenType::Number;
+    const auto I = TokenType::Identifier;
+    const auto O = TokenType::Operator;
+    const auto D = TokenType::Delimiter;
+
+    std::vector<TestCase> tests = {
+        // Hex literals: whole prefixed literal is one Number token.
+        {"0xFF", {{N, "0xFF"}}, "Hex literal uppercase digits"},
+        {"0xff", {{N, "0xff"}}, "Hex literal lowercase digits"},
+        {"0X1a2B", {{N, "0X1a2B"}}, "Hex literal uppercase X, mixed case"},
+        {"0x0", {{N, "0x0"}}, "Hex literal zero"},
+        {"SELECT 0xFF", {{TokenType::Keyword, "SELECT"}, {N, "0xFF"}},
+         "Hex literal after keyword"},
+        {"0xFF+1", {{N, "0xFF"}, {O, "+"}, {N, "1"}}, "Hex literal then operator"},
+
+        // Binary literals.
+        {"0b1010", {{N, "0b1010"}}, "Binary literal"},
+        {"0B1101", {{N, "0B1101"}}, "Binary literal uppercase B"},
+        {"0b0", {{N, "0b0"}}, "Binary literal zero"},
+
+        // Leading-dot floats.
+        {".5", {{N, ".5"}}, "Leading-dot float"},
+        {".25e3", {{N, ".25e3"}}, "Leading-dot float with exponent"},
+        {"(.5)", {{D, "("}, {N, ".5"}, {D, ")"}}, "Leading-dot float in parens"},
+
+        // Regression: existing decimal / exponent forms unchanged.
+        {"0", {{N, "0"}}, "Bare zero stays a number"},
+        {"42", {{N, "42"}}, "Plain integer"},
+        {"3.14", {{N, "3.14"}}, "Decimal"},
+        {"5.", {{N, "5."}}, "Trailing-dot float"},
+        {"1e10", {{N, "1e10"}}, "Exponent"},
+        {"1.5E-3", {{N, "1.5E-3"}}, "Signed exponent"},
+
+        // Regression: the `.` member operator and `t.*` must NOT be eaten into a
+        // number when no digit follows (the tokenizer emits `.` as an Operator).
+        {"a.b", {{I, "a"}, {O, "."}, {I, "b"}}, "Member dot untouched"},
+        {"t.*", {{I, "t"}, {O, "."}, {O, "*"}}, "t.* untouched"},
+    };
+
+    int passed = 0, failed = 0;
+    for (const auto& t : tests) {
+        if (run(t)) ++passed; else ++failed;
+    }
+
+    std::cout << "\n" << std::string(50, '=') << "\n";
+    std::cout << "Total: " << tests.size() << "  Passed: " << passed
+              << "  Failed: " << failed << "\n";
+
+    if (failed > 0) {
+        std::cout << "\nSome tests failed! Please review the failures above.\n";
+        return 1;
+    }
+    std::cout << "\nAll tests passed. No regressions detected.\n";
+    return 0;
+}


### PR DESCRIPTION
## Problem

`scan_number` stopped at the first non-decimal byte, which split two classes of numeric literal:

- **Hex / binary literals** — `0xFF` lexed as the number `0` followed by an identifier `xFF`. Downstream this silently evaluated to **0** rather than 255: a correctness bug, not merely a parse error. `0b1010` had the same fate.
- **Leading-dot floats** — `.5` never reached `scan_number`; it lexed as the `.` operator followed by `5`.

## Fix

- `scan_number` now recognises a `0x`/`0X` (base 16) or `0b`/`0B` (base 2) prefix and consumes the whole prefixed literal as a single `Number` token. The value is parsed downstream.
- `next_token` routes a `.` to `scan_number` **only when a digit follows**, so `.5` becomes a `Number` while the member `.` and `t.*` remain untouched.

## Tests

Adds `test_number_literals` (wired into CTest) covering:

- hex (`0xFF`, `0X1a2B`, `0x0`), binary (`0b1010`, `0B1101`), and their boundaries against following operators/keywords;
- leading-dot floats (`.5`, `.25e3`, `(.5)`);
- regression guards: bare `0`, plain integers, decimals, trailing-dot floats, exponents, and the `.` operator in `a.b` / `t.*`.

Each new-behaviour case is falsified by the pre-fix tokenizer (e.g. `0xFF` → two tokens), so the suite is a genuine regression guard. Existing operator / block-comment / SQL-file suites continue to pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyKDAbMWGwiZq4iJx3imsg)_