### PR TITLE
tokenizer: lex double-quoted lexemes as delimited identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,16 @@ if(BUILD_TESTS)
             DB25::Tokenizer
     )
 
+    # Delimited-identifier test executable - "..." lexes as an Identifier
+    add_executable(test_delimited_identifier
+        test/test_delimited_identifier.cpp
+    )
+
+    target_link_libraries(test_delimited_identifier
+        PRIVATE
+            DB25::Tokenizer
+    )
+
     # Copy test data to build directory
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/test/sql_test.sqls
@@ -314,6 +324,16 @@ if(BUILD_TESTS)
         FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
     )
 
+    add_test(
+        NAME DelimitedIdentifierTest
+        COMMAND test_delimited_identifier
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(DelimitedIdentifierTest PROPERTIES
+        PASS_REGULAR_EXPRESSION "All tests passed. No regressions detected"
+        FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
+    )
+
     # Performance regression test - ensure tokenizer is fast enough
     add_test(
         NAME PerformanceTest
@@ -327,7 +347,7 @@ if(BUILD_TESTS)
     # Set test properties for all tests
     set_tests_properties(TokenizerBasicTest TokenizerVerboseTest TokenizerOutputTest
                         OperatorTest InvalidOperatorTest BlockCommentTest
-                        NumberLiteralTest PerformanceTest
+                        NumberLiteralTest DelimitedIdentifierTest PerformanceTest
         PROPERTIES
             TIMEOUT 10
             LABELS "tokenizer"
@@ -337,7 +357,7 @@ if(BUILD_TESTS)
     add_custom_target(check
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
         DEPENDS test_sql_file test_operators test_invalid_operators test_block_comment
-                test_number_literals
+                test_number_literals test_delimited_identifier
         COMMENT "Running all tokenizer tests with strict validation"
     )
 endif()

--- a/include/simd_tokenizer.hpp
+++ b/include/simd_tokenizer.hpp
@@ -68,6 +68,7 @@ private:
     Token scan_identifier_or_keyword(size_t start, size_t start_line, size_t start_column);
     Token scan_number(size_t start, size_t start_line, size_t start_column);
     Token scan_string(size_t start, size_t start_line, size_t start_column, uint8_t quote);
+    Token scan_delimited_identifier(size_t start, size_t start_line, size_t start_column);
     Token scan_comment(size_t start, size_t start_line, size_t start_column);
     Token scan_block_comment(size_t start, size_t start_line, size_t start_column);
     Token scan_operator_or_delimiter(size_t start, size_t start_line, size_t start_column);

--- a/src/simd_tokenizer.cpp
+++ b/src/simd_tokenizer.cpp
@@ -84,10 +84,19 @@ Token SimdTokenizer::next_token() {
             return scan_number(start, start_line, start_column);
         }
 
+        // Double quote opens a delimited identifier (standard SQL / PostgreSQL /
+        // DuckDB), NOT a string literal: "select" is a column named select, and
+        // "user name" a column whose name has a space. It must be intercepted
+        // before the generic quote path, which would otherwise lex it as a
+        // String. Single quotes still make a string literal below.
+        if (first_char == '"') {
+            return scan_delimited_identifier(start, start_line, start_column);
+        }
+
         if (is_quote(first_char)) {
             return scan_string(start, start_line, start_column, first_char);
         }
-        
+
         if (first_char == '-' && position_ + 1 < input_size_ &&
             static_cast<uint8_t>(input_[position_ + 1]) == '-') {
             return scan_comment(start, start_line, start_column);
@@ -250,6 +259,55 @@ Token SimdTokenizer::scan_string(size_t start, size_t start_line, size_t start_c
         );
         
         return {TokenType::String, value, Keyword::UNKNOWN, start_line, start_column};
+    }
+
+Token SimdTokenizer::scan_delimited_identifier(size_t start, size_t start_line, size_t start_column) {
+        // start points at the opening '"'. The token value is the INNER text
+        // (the surrounding quotes stripped) so downstream code sees a plain
+        // identifier and never keyword-matches it. A doubled quote ("") inside
+        // is the SQL escape for one '"' and does not terminate the identifier;
+        // the escape is left un-collapsed in the value (a rare shape) so the
+        // lexer stays allocation-free - only the token boundary matters here.
+        (void)start;
+        ++position_;  // consume opening quote
+        ++column_;
+        const size_t inner_start = position_;
+
+        while (position_ < input_size_) {
+            uint8_t ch = static_cast<uint8_t>(input_[position_]);
+            if (ch == '"') {
+                if (position_ + 1 < input_size_ &&
+                    static_cast<uint8_t>(input_[position_ + 1]) == '"') {
+                    position_ += 2;  // escaped "" - part of the identifier
+                    column_ += 2;
+                    continue;
+                }
+                // Closing quote: value spans the inner text, quote excluded.
+                std::string_view value(
+                    reinterpret_cast<const char*>(input_ + inner_start),
+                    position_ - inner_start);
+                ++position_;  // consume closing quote
+                ++column_;
+                return {TokenType::Identifier, value, Keyword::UNKNOWN,
+                        start_line, start_column};
+            }
+            if (ch == '\n') {
+                ++position_;
+                ++line_;
+                column_ = 1;
+            } else {
+                ++position_;
+                ++column_;
+            }
+        }
+
+        // Unterminated: take the inner text to end of input (mirrors the string
+        // scanner's lenient EOF handling) rather than dropping the token.
+        std::string_view value(
+            reinterpret_cast<const char*>(input_ + inner_start),
+            position_ - inner_start);
+        return {TokenType::Identifier, value, Keyword::UNKNOWN,
+                start_line, start_column};
     }
 
 Token SimdTokenizer::scan_comment(size_t start, size_t start_line, size_t start_column) {

--- a/test/test_delimited_identifier.cpp
+++ b/test/test_delimited_identifier.cpp
@@ -1,0 +1,150 @@
+/*
+ * Delimited-identifier tokenization test for DB25 SQL Tokenizer
+ *
+ * A double-quoted lexeme is a delimited identifier (standard SQL / PostgreSQL /
+ * DuckDB), not a string literal. It must:
+ *   - emit an Identifier token whose value is the INNER text (quotes stripped);
+ *   - never be keyword-matched, so "select" is an identifier, not the keyword;
+ *   - preserve spaces, punctuation, and case inside the quotes;
+ *   - treat a doubled "" as an escaped quote that does not terminate it.
+ * Single-quoted lexemes must still tokenize as String literals (unchanged).
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include "simd_tokenizer.hpp"
+
+using namespace db25;
+
+struct TokExp {
+    TokenType type;
+    std::string value;
+};
+
+struct TestCase {
+    std::string sql;
+    std::vector<TokExp> expected;  // non-whitespace, non-EOF tokens
+    std::string description;
+};
+
+static const char* type_name(TokenType t) {
+    switch (t) {
+        case TokenType::Unknown: return "Unknown";
+        case TokenType::Keyword: return "Keyword";
+        case TokenType::Identifier: return "Identifier";
+        case TokenType::Number: return "Number";
+        case TokenType::String: return "String";
+        case TokenType::Operator: return "Operator";
+        case TokenType::Delimiter: return "Delimiter";
+        case TokenType::Comment: return "Comment";
+        case TokenType::Whitespace: return "Whitespace";
+        case TokenType::EndOfFile: return "EOF";
+        default: return "?";
+    }
+}
+
+static bool run(const TestCase& test) {
+    SimdTokenizer tokenizer(
+        reinterpret_cast<const std::byte*>(test.sql.data()),
+        test.sql.size());
+    auto tokens = tokenizer.tokenize();
+
+    std::vector<Token> actual;
+    for (const auto& tok : tokens) {
+        if (tok.type != TokenType::Whitespace && tok.type != TokenType::EndOfFile) {
+            actual.push_back(tok);
+        }
+    }
+
+    bool ok = actual.size() == test.expected.size();
+    for (size_t i = 0; ok && i < actual.size(); ++i) {
+        if (actual[i].type != test.expected[i].type ||
+            std::string(actual[i].value) != test.expected[i].value) {
+            ok = false;
+        }
+    }
+
+    if (!ok) {
+        std::cout << "FAIL: " << test.description << "\n";
+        std::cout << "  SQL: \"" << test.sql << "\"\n";
+        std::cout << "  Expected: ";
+        for (const auto& e : test.expected)
+            std::cout << "[" << type_name(e.type) << ":" << e.value << "] ";
+        std::cout << "\n  Got:      ";
+        for (const auto& a : actual)
+            std::cout << "[" << type_name(a.type) << ":" << std::string(a.value) << "] ";
+        std::cout << "\n";
+        return false;
+    }
+
+    std::cout << "PASS: " << test.description << "\n";
+    return true;
+}
+
+int main() {
+    std::cout << "DB25 Tokenizer - Delimited Identifier Test\n";
+    std::cout << "==========================================\n\n";
+
+    const auto ID = TokenType::Identifier;
+    const auto KW = TokenType::Keyword;
+    const auto STR = TokenType::String;
+    const auto OP = TokenType::Operator;
+    const auto DL = TokenType::Delimiter;
+
+    std::vector<TestCase> tests = {
+        // Value is the inner text, quotes stripped.
+        {"\"col\"", {{ID, "col"}}, "Simple delimited identifier"},
+        {"\"User Name\"", {{ID, "User Name"}}, "Identifier with a space"},
+        {"\"column-with-dashes\"", {{ID, "column-with-dashes"}}, "Identifier with dashes"},
+        {"\"MixedCase\"", {{ID, "MixedCase"}}, "Case is preserved"},
+
+        // A keyword inside quotes is an identifier, not a keyword.
+        {"\"select\"", {{ID, "select"}}, "Keyword as delimited identifier"},
+        {"\"FROM\"", {{ID, "FROM"}}, "Uppercase keyword as identifier"},
+
+        // Doubled "" is an escaped quote, not a terminator (one token).
+        {"\"a\"\"b\"", {{ID, "a\"\"b"}}, "Escaped doubled quote stays one token"},
+
+        // In context.
+        {"SELECT \"id\" FROM t",
+         {{KW, "SELECT"}, {ID, "id"}, {KW, "FROM"}, {ID, "t"}},
+         "Delimited identifier in a SELECT list"},
+        {"\"t\".\"c\"",
+         {{ID, "t"}, {OP, "."}, {ID, "c"}},
+         "Qualified delimited identifier"},
+
+        // Single quotes are STILL string literals (regression guard).
+        {"'hello'", {{STR, "'hello'"}}, "Single-quoted stays a String"},
+        {"WHERE x = 'active'",
+         {{KW, "WHERE"}, {ID, "x"}, {OP, "="}, {STR, "'active'"}},
+         "Single-quoted string in a predicate"},
+
+        // A double quote inside a single-quoted string is just string content.
+        {"'{\"active\": true}'",
+         {{STR, "'{\"active\": true}'"}},
+         "Double quote inside a single-quoted string is untouched"},
+
+        // Alias form.
+        {"SELECT x AS \"my col\" FROM t",
+         {{KW, "SELECT"}, {ID, "x"}, {KW, "AS"}, {ID, "my col"}, {KW, "FROM"}, {ID, "t"}},
+         "Delimited alias"},
+    };
+    (void)DL;
+
+    int passed = 0, failed = 0;
+    for (const auto& t : tests) {
+        if (run(t)) ++passed; else ++failed;
+    }
+
+    std::cout << "\n" << std::string(50, '=') << "\n";
+    std::cout << "Total: " << tests.size() << "  Passed: " << passed
+              << "  Failed: " << failed << "\n";
+
+    if (failed > 0) {
+        std::cout << "\nSome tests failed! Please review the failures above.\n";
+        return 1;
+    }
+    std::cout << "\nAll tests passed. No regressions detected.\n";
+    return 0;
+}


### PR DESCRIPTION
## Problem

A double-quoted lexeme is a **delimited identifier** in standard SQL / PostgreSQL / DuckDB — `"select"` is a column named `select`, `"user name"` a column whose name has a space. The tokenizer routed both `'` and `"` to `scan_string`, so a double-quoted name became a `String` token and could never resolve as a column, and a keyword or special-char name was simply unreachable.

## Fix

`next_token` now intercepts `"` ahead of the generic quote path and calls a new `scan_delimited_identifier`, which:

- emits an `Identifier` token whose value is the **inner text** (surrounding quotes stripped), so downstream code sees a plain identifier and never keyword-matches it;
- treats a doubled `""` as an escaped quote that does not terminate the identifier (left un-collapsed in the value — a rare shape — so the lexer stays allocation-free; only the token boundary matters at this layer);
- handles an unterminated identifier leniently to end-of-input, mirroring the string scanner.

Single quotes are unchanged and still produce `String` literals, and a `"` inside a single-quoted string remains ordinary string content.

## Tests

Adds `test_delimited_identifier` (wired into CTest) covering: inner-text value, keyword-as-identifier (`"select"`, `"FROM"`), spaces / dashes / case preservation, the `""` escape as one token, qualified (`"t"."c"`) and alias (`AS "my col"`) forms, and single-quote regression guards including a `"` embedded in a `'...'` string.

Rebased onto current `main` (after #9 merged); the number-literal and delimited-identifier test targets coexist. Full CTest suite: **9/9 pass**.
