### PR TITLE
tokenizer: drop redundant keyword SIMD; vectorize long whitespace runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,16 @@ if(BUILD_TESTS)
             DB25::Tokenizer
     )
 
+    # Lexer-invariants test - position tracking + keyword-table completeness
+    add_executable(test_lexer_invariants
+        test/test_lexer_invariants.cpp
+    )
+
+    target_link_libraries(test_lexer_invariants
+        PRIVATE
+            DB25::Tokenizer
+    )
+
     # Copy test data to build directory
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/test/sql_test.sqls
@@ -334,6 +344,16 @@ if(BUILD_TESTS)
         FAIL_REGULAR_EXPRESSION "FAIL;Failed: [1-9]"
     )
 
+    add_test(
+        NAME LexerInvariantsTest
+        COMMAND test_lexer_invariants
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(LexerInvariantsTest PROPERTIES
+        PASS_REGULAR_EXPRESSION "All tests passed. No regressions detected"
+        FAIL_REGULAR_EXPRESSION "FAIL;FAILURES"
+    )
+
     # Performance regression test - ensure tokenizer is fast enough
     add_test(
         NAME PerformanceTest
@@ -347,7 +367,8 @@ if(BUILD_TESTS)
     # Set test properties for all tests
     set_tests_properties(TokenizerBasicTest TokenizerVerboseTest TokenizerOutputTest
                         OperatorTest InvalidOperatorTest BlockCommentTest
-                        NumberLiteralTest DelimitedIdentifierTest PerformanceTest
+                        NumberLiteralTest DelimitedIdentifierTest
+                        LexerInvariantsTest PerformanceTest
         PROPERTIES
             TIMEOUT 10
             LABELS "tokenizer"
@@ -357,7 +378,7 @@ if(BUILD_TESTS)
     add_custom_target(check
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --verbose
         DEPENDS test_sql_file test_operators test_invalid_operators test_block_comment
-                test_number_literals test_delimited_identifier
+                test_number_literals test_delimited_identifier test_lexer_invariants
         COMMENT "Running all tokenizer tests with strict validation"
     )
 endif()

--- a/src/simd_tokenizer.cpp
+++ b/src/simd_tokenizer.cpp
@@ -11,6 +11,8 @@
 #include "simd_tokenizer.hpp"
 #include "char_classifier.hpp"
 
+#include <cstring>  // std::memchr (vectorized newline scan in update_position)
+
 namespace db25 {
 
 SimdTokenizer::SimdTokenizer(const std::byte* input, size_t size)
@@ -125,24 +127,16 @@ Token SimdTokenizer::scan_identifier_or_keyword(size_t start, size_t start_line,
             position_ - start
         );
         
-        // Use generated keyword lookup
+        // find_keyword is a complete, case-insensitive lookup over the whole
+        // keyword table (binary search after ASCII-upcasing), so it is
+        // authoritative: if it returns UNKNOWN the lexeme is not a keyword in any
+        // case. The previous SIMD fallback (is_keyword_simd) only ran after this
+        // returned UNKNOWN and checked the SAME table with the SAME case-folding,
+        // so it could never turn an identifier into a keyword - it was dead work
+        // on every identifier. Removed.
         Keyword kw = find_keyword(value);
         TokenType type = (kw != Keyword::UNKNOWN) ? TokenType::Keyword : TokenType::Identifier;
-        
-        // For even faster SIMD-based keyword matching (optional optimization)
-        if (kw == Keyword::UNKNOWN && value.length() <= 32) {
-            dispatcher_.dispatch([&](auto processor) {
-                return is_keyword_simd(processor, 
-                    input_ + start, 
-                    value.length(), 
-                    kw);
-            });
-            
-            if (kw != Keyword::UNKNOWN) {
-                type = TokenType::Keyword;
-            }
-        }
-        
+
         return {type, value, kw, start_line, start_column};
     }
 
@@ -406,16 +400,57 @@ Token SimdTokenizer::scan_operator_or_delimiter(size_t start, size_t start_line,
     }
 
 void SimdTokenizer::update_position(size_t count) {
-        for (size_t i = 0; i < count; ++i) {
-            uint8_t ch = static_cast<uint8_t>(input_[position_]);
-            if (ch == '\n') {
-                ++line_;
-                column_ = 1;
-            } else {
-                ++column_;
+        // Advance the source line/column over a run of `count` bytes (the
+        // whitespace skip_whitespace just measured).
+        //
+        // Short runs - the overwhelmingly common case, a single space or a few
+        // spaces between tokens - use the tight scalar loop: for so few bytes it
+        // beats std::memchr's call overhead (measured: memchr loses below ~16
+        // bytes, wins well above it). Long runs - deep indentation, blank-line
+        // gaps in formatted SQL - use memchr's vectorized newline scan, which is
+        // ~1.5x faster there. Both branches produce identical line/column, so the
+        // threshold is a pure performance knob, never a behavior change.
+        constexpr size_t kMemchrThreshold = 16;
+        if (count < kMemchrThreshold) {
+            for (size_t i = 0; i < count; ++i) {
+                if (static_cast<uint8_t>(input_[position_]) == '\n') {
+                    ++line_;
+                    column_ = 1;
+                } else {
+                    ++column_;
+                }
+                ++position_;
             }
-            ++position_;
+            return;
         }
+
+        // Long run: scan for newlines with memchr instead of walking every byte.
+        // The no-newline case reduces to a single column add; with newlines the
+        // final column is the distance past the last '\n' (1-based).
+        const char* run = reinterpret_cast<const char*>(input_ + position_);
+        const void* first_nl = std::memchr(run, '\n', count);
+        if (first_nl == nullptr) {
+            column_ += count;
+        } else {
+            size_t nlines = 0;
+            size_t last = 0;  // offset of the last '\n' within the run
+            const char* p = run;
+            size_t remaining = count;
+            for (const void* hit = first_nl; hit != nullptr;
+                 hit = std::memchr(p, '\n', remaining)) {
+                ++nlines;
+                const size_t off = static_cast<size_t>(static_cast<const char*>(hit) - run);
+                last = off;
+                p = run + off + 1;
+                remaining = count - (off + 1);
+                if (remaining == 0) {
+                    break;
+                }
+            }
+            line_ += nlines;
+            column_ = count - last;  // 1-based column after the final newline
+        }
+        position_ += count;
 }
 
 }  // namespace db25

--- a/test/test_lexer_invariants.cpp
+++ b/test/test_lexer_invariants.cpp
@@ -1,0 +1,118 @@
+/*
+ * Lexer invariants - regression guards for two performance cleanups:
+ *
+ *   1. Source position tracking (line/column). update_position() advances the
+ *      line/column over a whitespace run using a vectorized newline scan instead
+ *      of a per-byte loop; these cases pin the exact (line, column) of tokens
+ *      across leading whitespace, blank lines, tabs, and CRLF.
+ *
+ *   2. Keyword-table completeness. find_keyword() is the sole keyword classifier
+ *      (the redundant is_keyword_simd fallback was removed). It must therefore
+ *      resolve EVERY keyword in the table, in any ASCII case - otherwise a
+ *      keyword would silently lex as an identifier.
+ */
+
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "simd_tokenizer.hpp"
+#include "keywords.hpp"
+
+using namespace db25;
+
+static int g_fail = 0;
+
+static void expect(bool cond, const std::string& what) {
+    if (!cond) { std::printf("  FAIL: %s\n", what.c_str()); ++g_fail; }
+}
+
+// First non-whitespace token whose text equals `value`.
+static const Token* find_tok(const std::vector<Token>& toks, std::string_view value) {
+    for (const auto& t : toks) {
+        if (t.type != TokenType::Whitespace && t.value == value) return &t;
+    }
+    return nullptr;
+}
+
+static std::vector<Token> lex(const std::string& sql) {
+    SimdTokenizer t(reinterpret_cast<const std::byte*>(sql.data()), sql.size());
+    return t.tokenize();
+}
+
+// Assert a token's 1-based (line, column).
+static void at(const std::vector<Token>& toks, std::string_view value,
+               size_t line, size_t col, const std::string& ctx) {
+    const Token* t = find_tok(toks, value);
+    expect(t != nullptr, ctx + ": token '" + std::string{value} + "' present");
+    if (!t) return;
+    expect(t->line == line && t->column == col,
+           ctx + ": '" + std::string{value} + "' at (" + std::to_string(t->line) +
+               "," + std::to_string(t->column) + "), expected (" +
+               std::to_string(line) + "," + std::to_string(col) + ")");
+}
+
+static void test_positions() {
+    std::printf("position tracking\n");
+
+    // The input string MUST outlive the tokens - a Token's `value` is a
+    // string_view into it - so each case keeps the SQL in a named local.
+    { const std::string s = "SELECT x\nFROM t"; auto t = lex(s);
+      at(t, "SELECT", 1, 1, "newline-sep"); at(t, "x", 1, 8, "newline-sep");
+      at(t, "FROM", 2, 1, "newline-sep");   at(t, "t", 2, 6, "newline-sep"); }
+
+    { const std::string s = "  SELECT"; auto t = lex(s);       // leading spaces
+      at(t, "SELECT", 1, 3, "leading-spaces"); }
+
+    { const std::string s = "a\n\n\nb"; auto t = lex(s);       // blank lines
+      at(t, "a", 1, 1, "blank-lines"); at(t, "b", 4, 1, "blank-lines"); }
+
+    { const std::string s = "a\r\nb"; auto t = lex(s);         // CRLF: \r bumps col, \n resets
+      at(t, "a", 1, 1, "crlf"); at(t, "b", 2, 1, "crlf"); }
+
+    { const std::string s = "x\t\ty"; auto t = lex(s);         // tabs count as one column each
+      at(t, "x", 1, 1, "tabs"); at(t, "y", 1, 4, "tabs"); }
+
+    { const std::string s = "\n\nSELECT"; auto t = lex(s);     // leading blank lines
+      at(t, "SELECT", 3, 1, "leading-newlines"); }
+
+    { const std::string s = "SELECT\n   FROM"; auto t = lex(s);  // newline then indentation
+      at(t, "FROM", 2, 4, "indent-after-newline"); }
+
+    // Long whitespace runs (>= 16 bytes) exercise update_position's memchr
+    // branch; these must match the scalar branch exactly.
+    { const std::string s = "a" + std::string(20, ' ') + "b"; auto t = lex(s);  // 20 spaces, no newline
+      at(t, "a", 1, 1, "long-run-no-nl"); at(t, "b", 1, 22, "long-run-no-nl"); }
+
+    { const std::string s = "a\n" + std::string(20, ' ') + "b"; auto t = lex(s);  // nl + 20 spaces
+      at(t, "a", 1, 1, "long-run-nl"); at(t, "b", 2, 21, "long-run-nl"); }
+
+    { const std::string s = "a" + std::string(10, '\n') + std::string(18, ' ') + "b";
+      auto t = lex(s);  // 10 newlines + 18 spaces in one >=16-byte run
+      at(t, "a", 1, 1, "long-run-multi-nl"); at(t, "b", 11, 19, "long-run-multi-nl"); }
+}
+
+static void test_keyword_completeness() {
+    std::printf("keyword-table completeness (%zu keywords)\n", KEYWORDS.size());
+    for (const auto& e : KEYWORDS) {
+        std::string up(e.text);
+        std::string lo(e.text); for (char& c : lo) if (c >= 'A' && c <= 'Z') c = c - 'A' + 'a';
+        std::string mx(e.text); for (size_t i = 0; i < mx.size(); i += 2)
+            if (mx[i] >= 'A' && mx[i] <= 'Z') mx[i] = mx[i] - 'A' + 'a';
+        expect(find_keyword(up) == e.id, "upper '" + up + "'");
+        expect(find_keyword(lo) == e.id, "lower '" + lo + "'");
+        expect(find_keyword(mx) == e.id, "mixed '" + mx + "'");
+    }
+}
+
+int main() {
+    std::printf("DB25 Tokenizer - Lexer Invariants\n=================================\n\n");
+    test_positions();
+    test_keyword_completeness();
+
+    std::printf("\n%s\n", g_fail == 0
+        ? "All tests passed. No regressions detected."
+        : "FAILURES detected.");
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Two front-end performance cleanups in the tokenizer, both **behavior-preserving** — the full token-stream dump over the test corpus (3192 tokens, incl. `line`/`column`) is **byte-identical** before and after.

### 1. Remove the redundant `is_keyword_simd` fallback
`scan_identifier_or_keyword` ran `find_keyword` (a complete, case-insensitive binary search over the whole keyword table) and *then*, whenever it returned `UNKNOWN`, ran `is_keyword_simd` — a full length-bucket of SIMD keyword-compares plus a dispatcher dispatch — **on every identifier**. Since `find_keyword` is authoritative (proven: all 208 keywords resolve in upper/lower/mixed case) and `is_keyword_simd` checks the same table with the same case-folding, it could never reclassify an identifier. It was dead work on the hottest path.

All 208 keywords are pure ASCII `A–Z`, so `find_keyword`'s a–z upcasing and `matches_keyword`'s `& 0xDF` fold are provably equivalent on every input byte — the two matchers compute the identical keyword set.

### 2. Hybrid `update_position` — vectorize only long whitespace runs
The old loop walked every whitespace byte just to find newlines. Now short runs (the common single-/few-space gap) keep the tight scalar loop, and long runs (deep indentation, blank-line gaps in formatted SQL) use `std::memchr`'s vectorized newline scan. A 16-byte threshold routes between two branches that produce **identical** `line`/`column`/`position`, so there is no common-case regression.

## Measured (Xeon @ 2.1 GHz, `-O2`, `tokenize()` latency)

| input | before | after | |
|---|---:|---:|---|
| identifier-heavy | 6416 ns | 945 ns | **6.8× faster** (#1) |
| mixed corpus | 272 µs | 158 µs | **1.7× faster** (#1) |
| whitespace-heavy (deep indent) | 2500 ns | 1566 ns | **1.6× faster** (#2) |
| single-space (common case) | 624 ns | 623 ns | **flat — no regression** |

## Testing

- **Token-stream differential** old-vs-new over the corpus → byte-identical (type / keyword / line / column).
- New committed **`test_lexer_invariants`**: exact line/column across newlines, leading whitespace, blank lines, tabs, CRLF, **and long ≥16-byte runs that exercise the memchr branch**; plus a keyword-table completeness check that locks `find_keyword` as the sole authoritative classifier.
- **10/10 ctest**, and **10/10 under ASan + UBSan** (no over-read / UB in the memchr path).
- Three independent **adversarial reviews** (two on the proposal, one on the final diff) — all cleared with derivations: hybrid branches proven equivalent (incl. the `count==16` boundary and `count==0`), no over-read / underflow, and the keyword removal proven to leave every token unchanged.

No public API or behavior change; pure performance + a new regression test.
